### PR TITLE
Add default values to Struct to avoid packaging fail.

### DIFF
--- a/Source/SubsystemBrowser/Tests/SubsystemBrowserTestSubsystem.h
+++ b/Source/SubsystemBrowser/Tests/SubsystemBrowserTestSubsystem.h
@@ -23,11 +23,11 @@ struct FDemoStruct
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere)
-	int32 Foo;
+	int32 Foo = 0;
 	UPROPERTY(EditAnywhere)
-	int32 Bar;
+	int32 Bar = 0;
 	UPROPERTY(EditAnywhere)
-	EDemoEnum Baz;
+	EDemoEnum Baz = EDemoEnum::Alpha;
 };
 
 UCLASS(DefaultToInstanced, EditInlineNew)


### PR DESCRIPTION
When packaging project on `UE 5.2.1`, these uninitialized struct members would cause the packaging to fail. 
I don't know why it cared for an editor plugin, but it did.