### PR TITLE
Fix startup errors: Add default values to properties in FDemoStruct in SubsystemBrowserTestSubsystem.h

### DIFF
--- a/Source/SubsystemBrowser/Tests/SubsystemBrowserTestSubsystem.h
+++ b/Source/SubsystemBrowser/Tests/SubsystemBrowserTestSubsystem.h
@@ -23,11 +23,11 @@ struct FDemoStruct
 	GENERATED_BODY()
 
 	UPROPERTY(EditAnywhere)
-	int32 Foo;
+	int32 Foo = 0;
 	UPROPERTY(EditAnywhere)
-	int32 Bar;
+	int32 Bar = 0;
 	UPROPERTY(EditAnywhere)
-	EDemoEnum Baz;
+	EDemoEnum Baz = EDemoEnum::Alpha;
 };
 
 UCLASS(DefaultToInstanced, EditInlineNew)


### PR DESCRIPTION
```
Wed Oct 25 16:53:56 PDT 2023  Error        LogClass                  IntProperty FDemoStruct::Foo is not initialized properly. Module:SubsystemBrowser File:Tests/SubsystemBrowserTestSubsystem.h
Wed Oct 25 16:53:56 PDT 2023  Error        LogClass                  IntProperty FDemoStruct::Bar is not initialized properly. Module:SubsystemBrowser File:Tests/SubsystemBrowserTestSubsystem.h
Wed Oct 25 16:53:56 PDT 2023  Error        LogClass                  EnumProperty FDemoStruct::Baz is not initialized properly. Module:SubsystemBrowser File:Tests/SubsystemBrowserTestSubsystem.h
Wed Oct 25 16:53:56 PDT 2023  Error        LogAutomationTest         UObject.Class AttemptToFindUninitializedScriptStructMembers will be marked as failing due to errors being logged
Wed Oct 25 16:53:56 PDT 2023  Error        LogAutomationTest         LogClass: IntProperty FDemoStruct::Foo is not initialized properly. Module:SubsystemBrowser File:Tests/SubsystemBrowserTestSubsystem.h
Wed Oct 25 16:53:56 PDT 2023  Error        LogAutomationTest         LogClass: IntProperty FDemoStruct::Bar is not initialized properly. Module:SubsystemBrowser File:Tests/SubsystemBrowserTestSubsystem.h
Wed Oct 25 16:53:56 PDT 2023  Error        LogAutomationTest         LogClass: EnumProperty FDemoStruct::Baz is not initialized properly. Module:SubsystemBrowser File:Tests/SubsystemBrowserTestSubsystem.h
```